### PR TITLE
Add overflow-scrolling

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,6 +167,7 @@ var _validCSSProps = {
   'outline-style': true,
   'outline-width': true,
   'overflow': true,
+  'overflow-scrolling': true,
   'overflow-style': true,
   'overflow-x': true,
   'overflow-y': true,


### PR DESCRIPTION
This adds the `overflow-scrolling` property, which is used in Webkit as `-webkit-overflow-scrolling`. See http://css-tricks.com/snippets/css/momentum-scrolling-on-ios-overflow-elements/ for more details.
